### PR TITLE
Remove triple-redundant names in the test class instantiation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,9 +59,9 @@ All test classes are instantiated in the class `Program.cs` starting from the
 lines:
 ```
 /* Insert the test classes here */
-FB_PrimitiveTypes primitiveTypes = new FB_PrimitiveTypes(errorItems, "PrimitiveTypes");
-FB_AssertTrueFalse assertTrueFalse = new FB_AssertTrueFalse(errorItems, "AssertTrueFalse");
-FB_AssertEveryFailedTestTwice assertEveryFailedTestTwice = new FB_AssertEveryFailedTestTwice(errorItems, "AssertEveryFailedTestTwice");
+new FB_PrimitiveTypes(errorItems);
+new FB_AssertTrueFalse(errorItems);
+new FB_AssertEveryFailedTestTwice(errorItems);
 ...
 ...
 ...
@@ -86,9 +86,18 @@ VAR
 END_VAR
 ```
 The equivalent test class in TcVD needs to be instantiated with the second
-argument using the same name as in PRG_TEST, in this example:
+argument using the same name as in PRG_TEST. If not provided, the argument's default
+value is the C# class name with the `FB_` prefix removed (if any).
+
+In this example, the class name is `FB_AssertEveryFailedTestTwiceArrayVersion` and thus
+the test class's default argument value is `AssertEveryFailedTestTwiceArrayVersion`. The
+two lines below are equivalent, and the shorter form is preferred whenever possible to
+keep the code DRY (Don't Repeat Yourself).
+
 ```
-FB_AssertEveryFailedTestTwiceArrayVersion assertEveryFailedTestTwiceArrayVersion = new FB_AssertEveryFailedTestTwiceArrayVersion(errorItems, "AssertEveryFailedTestTwiceArrayVersion");
+new FB_AssertEveryFailedTestTwiceArrayVersion(errorItems);
+// equivalent to
+new FB_AssertEveryFailedTestTwiceArrayVersion(errorItems, "AssertEveryFailedTestTwiceArrayVersion");
 ```
 
 This is an example of how it can look running the TcUnit-Verifier_DotNet:

--- a/TcUnit-Verifier_DotNet/TcUnit-Verifier/FB_AdjustAssertFailureMessageToMax252CharLengthTest.cs
+++ b/TcUnit-Verifier_DotNet/TcUnit-Verifier/FB_AdjustAssertFailureMessageToMax252CharLengthTest.cs
@@ -9,7 +9,7 @@ namespace TcUnit.Verifier
 {
     class FB_AdjustAssertFailureMessageToMax252CharLengthTest : TestFunctionBlockAssert
     {
-        public FB_AdjustAssertFailureMessageToMax252CharLengthTest(ErrorItems errorItems, string testFunctionBlockInstance) : base(errorItems, testFunctionBlockInstance)
+        public FB_AdjustAssertFailureMessageToMax252CharLengthTest(ErrorItems errorItems, string testFunctionBlockInstance = null) : base(errorItems, testFunctionBlockInstance)
         {
             TestInstancePath252CharsExpectTooLongTestInstancePath();
             TestInstancePath220CharsExpectShortenedTestInstancePath();

--- a/TcUnit-Verifier_DotNet/TcUnit-Verifier/FB_AnyPrimitiveTypes.cs
+++ b/TcUnit-Verifier_DotNet/TcUnit-Verifier/FB_AnyPrimitiveTypes.cs
@@ -9,7 +9,7 @@ namespace TcUnit.Verifier
 {
     class FB_AnyPrimitiveTypes : TestFunctionBlockAssert
     {
-        public FB_AnyPrimitiveTypes(ErrorItems errorItems, string testFunctionBlockInstance) : base(errorItems, testFunctionBlockInstance)
+        public FB_AnyPrimitiveTypes(ErrorItems errorItems, string testFunctionBlockInstance = null) : base(errorItems, testFunctionBlockInstance)
         {
             Test_ANY_BYTE_Equals();
             Test_ANY_BYTE_Differ();

--- a/TcUnit-Verifier_DotNet/TcUnit-Verifier/FB_AnyToUnionValue.cs
+++ b/TcUnit-Verifier_DotNet/TcUnit-Verifier/FB_AnyToUnionValue.cs
@@ -9,7 +9,7 @@ namespace TcUnit.Verifier
 {
     class FB_AnyToUnionValue : TestFunctionBlockAssert
     {
-        public FB_AnyToUnionValue(ErrorItems errorItems, string testFunctionBlockInstance) : base(errorItems, testFunctionBlockInstance)
+        public FB_AnyToUnionValue(ErrorItems errorItems, string testFunctionBlockInstance = null) : base(errorItems, testFunctionBlockInstance)
         {
             Test_BOOL();
             Test_BIT();

--- a/TcUnit-Verifier_DotNet/TcUnit-Verifier/FB_ArrayPrimitiveTypes.cs
+++ b/TcUnit-Verifier_DotNet/TcUnit-Verifier/FB_ArrayPrimitiveTypes.cs
@@ -9,7 +9,7 @@ namespace TcUnit.Verifier
 {
     class FB_ArrayPrimitiveTypes : TestFunctionBlockAssert
     {
-        public FB_ArrayPrimitiveTypes(ErrorItems errorItems, string testFunctionBlockInstance) : base(errorItems, testFunctionBlockInstance)
+        public FB_ArrayPrimitiveTypes(ErrorItems errorItems, string testFunctionBlockInstance = null) : base(errorItems, testFunctionBlockInstance)
         {
             Test_BOOL_Array_Equals();
             Test_BOOL_Array_DifferInSize();

--- a/TcUnit-Verifier_DotNet/TcUnit-Verifier/FB_AssertEveryFailedTestTwice.cs
+++ b/TcUnit-Verifier_DotNet/TcUnit-Verifier/FB_AssertEveryFailedTestTwice.cs
@@ -9,7 +9,7 @@ namespace TcUnit.Verifier
 {
     class FB_AssertEveryFailedTestTwice : TestFunctionBlockAssert
     {
-        public FB_AssertEveryFailedTestTwice(ErrorItems errorItems, string testFunctionBlockInstance) : base(errorItems, testFunctionBlockInstance)
+        public FB_AssertEveryFailedTestTwice(ErrorItems errorItems, string testFunctionBlockInstance = null) : base(errorItems, testFunctionBlockInstance)
         {
             TwiceAssertCall();
         }

--- a/TcUnit-Verifier_DotNet/TcUnit-Verifier/FB_AssertEveryFailedTestTwiceArrayVersion.cs
+++ b/TcUnit-Verifier_DotNet/TcUnit-Verifier/FB_AssertEveryFailedTestTwiceArrayVersion.cs
@@ -9,7 +9,7 @@ namespace TcUnit.Verifier
 {
     class FB_AssertEveryFailedTestTwiceArrayVersion : TestFunctionBlockAssert
     {
-        public FB_AssertEveryFailedTestTwiceArrayVersion(ErrorItems errorItems, string testFunctionBlockInstance) : base(errorItems, testFunctionBlockInstance)
+        public FB_AssertEveryFailedTestTwiceArrayVersion(ErrorItems errorItems, string testFunctionBlockInstance = null) : base(errorItems, testFunctionBlockInstance)
         {
             TwiceAssertCall_Arrays();
         }

--- a/TcUnit-Verifier_DotNet/TcUnit-Verifier/FB_AssertTrueFalse.cs
+++ b/TcUnit-Verifier_DotNet/TcUnit-Verifier/FB_AssertTrueFalse.cs
@@ -9,7 +9,7 @@ namespace TcUnit.Verifier
 {
     class FB_AssertTrueFalse : TestFunctionBlockAssert
     {
-        public FB_AssertTrueFalse(ErrorItems errorItems, string testFunctionBlockInstance) : base(errorItems, testFunctionBlockInstance)
+        public FB_AssertTrueFalse(ErrorItems errorItems, string testFunctionBlockInstance = null) : base(errorItems, testFunctionBlockInstance)
         {
             AssertThatINTsAreEqual();
             AssertThatINTsAreNotEqual();

--- a/TcUnit-Verifier_DotNet/TcUnit-Verifier/FB_CheckIfSpecificTestIsFinished.cs
+++ b/TcUnit-Verifier_DotNet/TcUnit-Verifier/FB_CheckIfSpecificTestIsFinished.cs
@@ -9,7 +9,7 @@ namespace TcUnit.Verifier
 {
     class FB_CheckIfSpecificTestIsFinished : TestFunctionBlockAssert
     {
-        public FB_CheckIfSpecificTestIsFinished(ErrorItems errorItems, string testFunctionBlockInstance) : base(errorItems, testFunctionBlockInstance)
+        public FB_CheckIfSpecificTestIsFinished(ErrorItems errorItems, string testFunctionBlockInstance = null) : base(errorItems, testFunctionBlockInstance)
         {
             TestThatInstantlyFinishes();
         }

--- a/TcUnit-Verifier_DotNet/TcUnit-Verifier/FB_CreateDisabledTest.cs
+++ b/TcUnit-Verifier_DotNet/TcUnit-Verifier/FB_CreateDisabledTest.cs
@@ -9,7 +9,7 @@ namespace TcUnit.Verifier
 {
     class FB_CreateDisabledTest : TestFunctionBlockAssert
     {
-        public FB_CreateDisabledTest(ErrorItems errorItems, string testFunctionBlockInstance) : base(errorItems, testFunctionBlockInstance)
+        public FB_CreateDisabledTest(ErrorItems errorItems, string testFunctionBlockInstance = null) : base(errorItems, testFunctionBlockInstance)
         {
             TestEnabled();
             TestDisabled();

--- a/TcUnit-Verifier_DotNet/TcUnit-Verifier/FB_CreateFourTestsWithSameName.cs
+++ b/TcUnit-Verifier_DotNet/TcUnit-Verifier/FB_CreateFourTestsWithSameName.cs
@@ -9,7 +9,7 @@ namespace TcUnit.Verifier
 {
     class FB_CreateFourTestsWithSameName : TestFunctionBlockAssert
     {
-        public FB_CreateFourTestsWithSameName(ErrorItems errorItems, string testFunctionBlockInstance) : base(errorItems, testFunctionBlockInstance)
+        public FB_CreateFourTestsWithSameName(ErrorItems errorItems, string testFunctionBlockInstance = null) : base(errorItems, testFunctionBlockInstance)
         {
             TestOne();
         }

--- a/TcUnit-Verifier_DotNet/TcUnit-Verifier/FB_MultipleAssertWithSameParametersInDifferentCyclesAndInSameTest.cs
+++ b/TcUnit-Verifier_DotNet/TcUnit-Verifier/FB_MultipleAssertWithSameParametersInDifferentCyclesAndInSameTest.cs
@@ -9,7 +9,7 @@ namespace TcUnit.Verifier
 {
     class FB_MultipleAssertWithSameParametersInDifferentCyclesAndInSameTest : TestFunctionBlockAssert
     {
-        public FB_MultipleAssertWithSameParametersInDifferentCyclesAndInSameTest(ErrorItems errorItems, string testFunctionBlockInstance) : base(errorItems, testFunctionBlockInstance)
+        public FB_MultipleAssertWithSameParametersInDifferentCyclesAndInSameTest(ErrorItems errorItems, string testFunctionBlockInstance = null) : base(errorItems, testFunctionBlockInstance)
         {
             Assert_SeveralTimes();
         }

--- a/TcUnit-Verifier_DotNet/TcUnit-Verifier/FB_MultipleAssertWithSameParametersInDifferentCyclesButWithDifferentTests.cs
+++ b/TcUnit-Verifier_DotNet/TcUnit-Verifier/FB_MultipleAssertWithSameParametersInDifferentCyclesButWithDifferentTests.cs
@@ -9,7 +9,7 @@ namespace TcUnit.Verifier
 {
     class FB_MultipleAssertWithSameParametersInDifferentCyclesButWithDifferentTests : TestFunctionBlockAssert
     {
-        public FB_MultipleAssertWithSameParametersInDifferentCyclesButWithDifferentTests(ErrorItems errorItems, string testFunctionBlockInstance) : base(errorItems, testFunctionBlockInstance)
+        public FB_MultipleAssertWithSameParametersInDifferentCyclesButWithDifferentTests(ErrorItems errorItems, string testFunctionBlockInstance = null) : base(errorItems, testFunctionBlockInstance)
         {
             Assert_SeveralTimes();
             Assert_SeveralTimesAgain();

--- a/TcUnit-Verifier_DotNet/TcUnit-Verifier/FB_MultipleAssertWithSameParametersInSameCycleWithSameTest.cs
+++ b/TcUnit-Verifier_DotNet/TcUnit-Verifier/FB_MultipleAssertWithSameParametersInSameCycleWithSameTest.cs
@@ -9,7 +9,7 @@ namespace TcUnit.Verifier
 {
     class FB_MultipleAssertWithSameParametersInSameCycleWithSameTest : TestFunctionBlockAssert
     {
-        public FB_MultipleAssertWithSameParametersInSameCycleWithSameTest(ErrorItems errorItems, string testFunctionBlockInstance) : base(errorItems, testFunctionBlockInstance)
+        public FB_MultipleAssertWithSameParametersInSameCycleWithSameTest(ErrorItems errorItems, string testFunctionBlockInstance = null) : base(errorItems, testFunctionBlockInstance)
         {
             Assert_SeveralTimes();
         }

--- a/TcUnit-Verifier_DotNet/TcUnit-Verifier/FB_PrimitiveTypes.cs
+++ b/TcUnit-Verifier_DotNet/TcUnit-Verifier/FB_PrimitiveTypes.cs
@@ -9,7 +9,7 @@ namespace TcUnit.Verifier
 {
     class FB_PrimitiveTypes : TestFunctionBlockAssert
     {
-        public FB_PrimitiveTypes(ErrorItems errorItems, string testFunctionBlockInstance) : base(errorItems, testFunctionBlockInstance)
+        public FB_PrimitiveTypes(ErrorItems errorItems, string testFunctionBlockInstance = null) : base(errorItems, testFunctionBlockInstance)
         {
             Test_ANY_Equals();
             Test_ANY_Differ_DataType();

--- a/TcUnit-Verifier_DotNet/TcUnit-Verifier/FB_SkipAssertionsWhenFinished.cs
+++ b/TcUnit-Verifier_DotNet/TcUnit-Verifier/FB_SkipAssertionsWhenFinished.cs
@@ -9,7 +9,7 @@ namespace TcUnit.Verifier
 {
     class FB_SkipAssertionsWhenFinished : TestFunctionBlockAssert
     {
-        public FB_SkipAssertionsWhenFinished(ErrorItems errorItems, string testFunctionBlockInstance)
+        public FB_SkipAssertionsWhenFinished(ErrorItems errorItems, string testFunctionBlockInstance = null)
             : base(errorItems, testFunctionBlockInstance)
         {
             Test_LongTest();

--- a/TcUnit-Verifier_DotNet/TcUnit-Verifier/FB_TestFinishedNamed.cs
+++ b/TcUnit-Verifier_DotNet/TcUnit-Verifier/FB_TestFinishedNamed.cs
@@ -9,7 +9,7 @@ namespace TcUnit.Verifier
 {
     class FB_TestFinishedNamed : TestFunctionBlockAssert
     {
-        public FB_TestFinishedNamed(ErrorItems errorItems, string testFunctionBlockInstance)
+        public FB_TestFinishedNamed(ErrorItems errorItems, string testFunctionBlockInstance = null)
             : base(errorItems, testFunctionBlockInstance)
         {
             Test_FinishedNamed();

--- a/TcUnit-Verifier_DotNet/TcUnit-Verifier/Program.cs
+++ b/TcUnit-Verifier_DotNet/TcUnit-Verifier/Program.cs
@@ -150,22 +150,22 @@ namespace TcUnit.Verifier
             }
 
             /* Insert the test classes here */
-            FB_PrimitiveTypes primitiveTypes = new FB_PrimitiveTypes(errorItems, "PrimitiveTypes");
-            FB_AssertTrueFalse assertTrueFalse = new FB_AssertTrueFalse(errorItems, "AssertTrueFalse");
-            FB_AssertEveryFailedTestTwice assertEveryFailedTestTwice = new FB_AssertEveryFailedTestTwice(errorItems, "AssertEveryFailedTestTwice");
-            FB_CreateFourTestsWithSameName createFourTestsWithSameName = new FB_CreateFourTestsWithSameName(errorItems, "CreateFourTestsWithSameName");
-            FB_ArrayPrimitiveTypes arrayPrimitiveTypes = new FB_ArrayPrimitiveTypes(errorItems, "ArrayPrimitiveTypes");
-            FB_CreateDisabledTest createDisabledTest = new FB_CreateDisabledTest(errorItems, "CreateDisabledTest");
-            FB_AnyPrimitiveTypes anyPrimitiveTypes = new FB_AnyPrimitiveTypes(errorItems, "AnyPrimitiveTypes");
-            FB_AssertEveryFailedTestTwiceArrayVersion assertEveryFailedTestTwiceArrayVersion = new FB_AssertEveryFailedTestTwiceArrayVersion(errorItems, "AssertEveryFailedTestTwiceArrayVersion");
-            FB_AnyToUnionValue anyToUnionValue = new FB_AnyToUnionValue(errorItems, "AnyToUnionValue");
-            FB_MultipleAssertWithSameParametersInSameCycleWithSameTest multipleAssertWithSameParametersInSameCycleWithSameTest = new FB_MultipleAssertWithSameParametersInSameCycleWithSameTest(errorItems, "MultipleAssertWithSameParametersInSameCycleWithSameTest");
-            FB_MultipleAssertWithSameParametersInDifferentCyclesButWithDifferentTests multipleAssertWithSameParametersInDifferentCyclesButWithDifferentTests = new FB_MultipleAssertWithSameParametersInDifferentCyclesButWithDifferentTests(errorItems, "MultipleAssertWithSameParametersInDifferentCyclesButWithDifferentTests");
-            FB_MultipleAssertWithSameParametersInDifferentCyclesAndInSameTest multipleAssertWithSameParametersInDifferentCyclesAndInSameTest = new FB_MultipleAssertWithSameParametersInDifferentCyclesAndInSameTest(errorItems, "MultipleAssertWithSameParametersInDifferentCyclesAndInSameTest");
-            FB_SkipAssertionsWhenFinished skipAssertionsWhenFinished = new FB_SkipAssertionsWhenFinished(errorItems, "SkipAssertionsWhenFinished");
-            FB_AdjustAssertFailureMessageToMax252CharLengthTest adjustAssertFailureMessageToMax252CharLengthTest = new FB_AdjustAssertFailureMessageToMax252CharLengthTest(errorItems, "AdjustAssertFailureMessageToMax252CharLengthTest");
-            FB_CheckIfSpecificTestIsFinished checkIfSpecificTestIsFinished = new FB_CheckIfSpecificTestIsFinished(errorItems, "CheckIfSpecificTestIsFinished");
-            FB_TestFinishedNamed testFinishedNamed = new FB_TestFinishedNamed(errorItems, "TestFinishedNamed");
+            new FB_PrimitiveTypes(errorItems);
+            new FB_AssertTrueFalse(errorItems);
+            new FB_AssertEveryFailedTestTwice(errorItems);
+            new FB_CreateFourTestsWithSameName(errorItems);
+            new FB_ArrayPrimitiveTypes(errorItems);
+            new FB_CreateDisabledTest(errorItems);
+            new FB_AnyPrimitiveTypes(errorItems);
+            new FB_AssertEveryFailedTestTwiceArrayVersion(errorItems);
+            new FB_AnyToUnionValue(errorItems);
+            new FB_MultipleAssertWithSameParametersInSameCycleWithSameTest(errorItems);
+            new FB_MultipleAssertWithSameParametersInDifferentCyclesButWithDifferentTests(errorItems);
+            new FB_MultipleAssertWithSameParametersInDifferentCyclesAndInSameTest(errorItems);
+            new FB_SkipAssertionsWhenFinished(errorItems);
+            new FB_AdjustAssertFailureMessageToMax252CharLengthTest(errorItems);
+            new FB_CheckIfSpecificTestIsFinished(errorItems);
+            new FB_TestFinishedNamed(errorItems);
 
             log.Info("Done.");
 

--- a/TcUnit-Verifier_DotNet/TcUnit-Verifier/TestFunctionBlockAssert.cs
+++ b/TcUnit-Verifier_DotNet/TcUnit-Verifier/TestFunctionBlockAssert.cs
@@ -12,10 +12,21 @@ namespace TcUnit.Verifier
         protected ErrorItems _errorItems;
         protected string _testFunctionBlockInstance;
 
-        public TestFunctionBlockAssert(ErrorItems errorItems, string testFunctionBlockInstance)
+        private string DefaultFunctionBlockInstance
+        {
+            get
+            {
+                string className = this.GetType().Name;
+                if (className.StartsWith("FB_"))
+                    return className.Remove(0, 3);
+                return className;
+            }
+        }
+
+        public TestFunctionBlockAssert(ErrorItems errorItems, string testFunctionBlockInstance = null)
         {
             _errorItems = errorItems;
-            _testFunctionBlockInstance = testFunctionBlockInstance;
+            _testFunctionBlockInstance = testFunctionBlockInstance ?? DefaultFunctionBlockInstance;
         }
 
         protected string CreateFailedTestMessage(string method, string expected, string actual, string message)


### PR DESCRIPTION
Takes care of Issue #13.